### PR TITLE
[Fix] Update SQL IP address to use static IP

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,21 +3,21 @@
     "username": "ju",
     "password": "password",
     "database": "nogeut_db",
-    "host": "34.22.75.139",
+    "host": "34.64.149.33",
     "dialect": "mysql"
   },
   "test": {
     "username": "ju",
     "password": "password",
     "database": "nogeut_db",
-    "host": "34.22.75.139",
+    "host": "34.64.149.33",
     "dialect": "mysql"
   },
   "production": {
     "username": "ju",
     "password": "password",
     "database": "nogeut_db",
-    "host": "34.22.75.139",
+    "host": "34.64.149.33",
     "dialect": "mysql"
   }
 }


### PR DESCRIPTION
- Updated the SQL server to use a static IP for improved stability and easier management.
- Changed the configuration file to reflect the new static IP address.
- Verified database connectivity with the updated IP address to ensure no disruptions.